### PR TITLE
Exclude for version 3.0.0 of discord api

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
 	</requiredpackages>
 	<excludedpackages>
 		<excludedpackage version="7.0.0 Alpha 1">com.woltlab.wcf</excludedpackage>
+		<excludedpackage version="3.0.0 Alpha 1">dev.hanashi.wsc.discord-api</excludedpackage>
 	</excludedpackages>
 	<instructions type="install">
 		<instruction type="file"/>


### PR DESCRIPTION
I have added an exclude to the Discord API for version 3.0.0. The long-term plan is that version 3.0.0 will get a complete rework and will probably contain breaking changes.